### PR TITLE
Fix UCSB authentication for iOS

### DIFF
--- a/app/canvas-auth.tsx
+++ b/app/canvas-auth.tsx
@@ -1,77 +1,18 @@
-import {WebView} from 'react-native-webview';
-import {router, useLocalSearchParams} from 'expo-router';
-import * as CookieHandler from 'react-native-cookie-handler';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import generateAuth from "@/helpers/auth";
 
-type Cookies = { [p: string]: string };
-type PathName = "/" | `./${string}` | `../${string}` | ".." | `${string}:${string}`;
-const COOKIE_KEY = "canvas.cookie";
-
-function stringifyCookies(cookies: Cookies) {
-  return Object.entries(cookies).map(([name, value]) => `${name}=${value}`).join("; ");
-}
-
-async function checkAuth(cookies: Cookies): Promise<string | false> {
-  const cookie = stringifyCookies(cookies);
-  const response = await fetch("https://ucsb.instructure.com/api/v1/users/self", {
-    "method": "GET",
-    "headers": {
+export const [CanvasAuth, useCanvasAuth] = generateAuth(
+    "/canvas-auth",
+    "canvas_auth",
+    "canvas.cookie",
+    "https://ucsb.instructure.com/api/v1/users/self",
+    "https://ucsb.instructure.com/",
+    "https://ucsb.instructure.com/",
+    cookie => ({
       "accept": "*/*",
       "accept-language": "en-US,en;q=0.9",
       "cookie": cookie
-    }
-  });
-  return response.ok && cookie;
-}
+    }),
+    response => response.ok
+);
 
-export default function CanvasAuth() {
-  const {redirect}: {redirect: PathName} = useLocalSearchParams();
-  return (
-      <WebView
-          source={{uri: "https://ucsb.instructure.com/"}}
-          onNavigationStateChange={async (navState) => {
-            if (navState.url === "https://ucsb.instructure.com/") {
-              const cookies = await CookieHandler.get("https://ucsb.instructure.com/", true);
-              if (await checkAuth(cookies)) {
-                router.navigate({
-                  pathname: redirect,
-                  params: {canvas_cookies: encodeURIComponent(JSON.stringify(cookies))}
-                });
-              }
-            }
-          }}
-          javaScriptEnabled={true}
-          domStorageEnabled={true}
-          startInLoadingState={false}
-      />
-  );
-}
-
-async function handleCookies(cookies: Cookies): Promise<string> {
-  const cookie = await checkAuth(cookies);
-  if (cookie) {
-    await AsyncStorage.setItem(COOKIE_KEY, JSON.stringify(cookies));
-    return cookie;
-  } else {
-    throw "Authentication error";
-  }
-}
-
-function navigate(redirect: PathName) {
-  router.navigate({pathname: '/canvas-auth', params: {redirect}});
-}
-
-export function useCanvasAuth(redirect: PathName, callback: (cookie: string) => any): void {
-  const params = useLocalSearchParams();
-  if (params.canvas_cookies) {
-    const cookieJSON = typeof params.canvas_cookies === "string" ? params.canvas_cookies : params.canvas_cookies[0];
-    const cookies: Cookies = JSON.parse(cookieJSON);
-    handleCookies(cookies).then(callback, () => navigate(redirect));
-  } else {
-    (async () => {
-      const cookieJSON = await AsyncStorage.getItem(COOKIE_KEY);
-      const cookies: Cookies = cookieJSON ? JSON.parse(cookieJSON) : await CookieHandler.get("https://ucsb.instructure.com/", true);
-      handleCookies(cookies).then(callback, () => navigate(redirect));
-    })();
-  }
-}
+export default CanvasAuth;

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -5,26 +5,21 @@ import {useUCSBAuth} from "@/app/ucsb-auth";
 import {jsdom} from 'jsdom-jscore-rn';
 
 export default function Index() {
-  useCanvasAuth("/", async () => {
+  useCanvasAuth("/", async headers => {
     const response = await fetch("https://ucsb.instructure.com/api/v1/users/self", {
       "method": "GET",
-      "headers": {
-        "accept": "application/json",
-        "accept-language": "en-US,en;q=0.9"
-      }
+      "headers": headers
     });
     Alert.alert("Canvas API Response", await response.text());
   });
 
-  useUCSBAuth("/", async () => {
-    const response = await fetch("https://my.sa.ucsb.edu/gold/WeeklyStudentSchedule.aspx", {
+  useUCSBAuth("/", async headers => {
+    const response = await fetch("https://api-transformer.onrender.com//https://my.sa.ucsb.edu/gold/WeeklyStudentSchedule.aspx", {
       "method": "GET",
-      "headers": {
-        "accept": "text/html",
-        "accept-language": "en-US,en;q=0.9"
-      }
+      "headers": headers
     });
     const dom = jsdom(await response.text());
+    console.log("Dom", dom.title);
     const eventsElement = dom.querySelector('#pageContent_events');
     if (eventsElement) {
       const events: {[p: string]: {

--- a/app/ucsb-auth.tsx
+++ b/app/ucsb-auth.tsx
@@ -1,77 +1,21 @@
-import {WebView} from 'react-native-webview';
-import {router, useLocalSearchParams} from 'expo-router';
-import * as CookieHandler from 'react-native-cookie-handler';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+import generateAuth from "@/helpers/auth";
 
-type Cookies = { [p: string]: string };
-type PathName = "/" | `./${string}` | `../${string}` | ".." | `${string}:${string}`;
-const COOKIE_KEY = "ucsb.cookie";
+export const [UCSBAuth, useUCSBAuth] = generateAuth(
+    "/ucsb-auth",
+    "ucsb_auth",
+    "ucsb.cookie",
+    "https://api-transformer.onrender.com//https://my.sa.ucsb.edu/gold/Home.aspx",
+    "https://my.sa.ucsb.edu/gold/Home.aspx",
+    "https://my.sa.ucsb.edu/gold/",
+    cookie => ({
+      "headers": JSON.stringify({
+        "accept": "*/*",
+        "accept-language": "en-US,en;q=0.9",
+        "cookie": cookie,
+      })
+    }),
+    response => response.status === 200
+        && response.url === "https://api-transformer.onrender.com//https://my.sa.ucsb.edu/gold/Home.aspx"
+);
 
-function stringifyCookies(cookies: Cookies) {
-  return Object.entries(cookies).map(([name, value]) => `${name}=${value}`).join("; ");
-}
-
-async function checkAuth(cookies: Cookies): Promise<string | false> {
-  const cookie = stringifyCookies(cookies);
-  const response = await fetch("https://my.sa.ucsb.edu/gold/Home.aspx", {
-    "method": "GET",
-    "headers": {
-      "accept": "*/*",
-      "accept-language": "en-US,en;q=0.9",
-      "cookie": cookie
-    }
-  });
-  return response.url === "https://my.sa.ucsb.edu/gold/Home.aspx" && cookie;
-}
-
-export default function CanvasAuth() {
-  const {redirect}: {redirect: PathName} = useLocalSearchParams();
-  return (
-      <WebView
-          source={{uri: "https://my.sa.ucsb.edu/gold/Home.aspx"}}
-          onNavigationStateChange={async (navState) => {
-            if (navState.url === "https://my.sa.ucsb.edu/gold/Home.aspx") {
-              const cookies = await CookieHandler.get("https://my.sa.ucsb.edu/gold/", true);
-              if (await checkAuth(cookies)) {
-                router.navigate({
-                  pathname: redirect,
-                  params: {ucsb_cookies: encodeURIComponent(JSON.stringify(cookies))}
-                });
-              }
-            }
-          }}
-          javaScriptEnabled={true}
-          domStorageEnabled={true}
-          startInLoadingState={false}
-      />
-  );
-}
-
-async function handleCookies(cookies: Cookies): Promise<string> {
-  const cookie = await checkAuth(cookies);
-  if (cookie) {
-    await AsyncStorage.setItem(COOKIE_KEY, JSON.stringify(cookies));
-    return cookie;
-  } else {
-    throw "Authentication error";
-  }
-}
-
-function navigate(redirect: PathName) {
-  router.navigate({pathname: '/ucsb-auth', params: {redirect}});
-}
-
-export function useUCSBAuth(redirect: PathName, callback: (cookie: string) => any): void {
-  const params = useLocalSearchParams();
-  if (params.ucsb_cookies) {
-    const cookieJSON = typeof params.ucsb_cookies === "string" ? params.ucsb_cookies : params.ucsb_cookies[0];
-    const cookies: Cookies = JSON.parse(cookieJSON);
-    handleCookies(cookies).then(callback, () => navigate(redirect));
-  } else {
-    (async () => {
-      const cookieJSON = await AsyncStorage.getItem(COOKIE_KEY);
-      const cookies: Cookies = cookieJSON ? JSON.parse(cookieJSON) : await CookieHandler.get("https://ucsb.instructure.com/", true);
-      handleCookies(cookies).then(callback, () => navigate(redirect));
-    })();
-  }
-}
+export default UCSBAuth;

--- a/helpers/auth.tsx
+++ b/helpers/auth.tsx
@@ -1,0 +1,92 @@
+import {WebView} from 'react-native-webview';
+import {router, Routes, useLocalSearchParams} from 'expo-router';
+import * as CookieHandler from 'react-native-cookie-handler';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import React from "react";
+
+type Cookies = Record<string, string>;
+
+function stringifyCookies(cookies: Cookies) {
+  return Object.entries(cookies).map(([name, value]) => `${name}=${value}`).join("; ");
+}
+
+export default function generateAuth(pathname: Routes,
+                                     param_key: string,
+                                     cookie_key: string,
+                                     api_test_url: string,
+                                     start_url: string,
+                                     cookie_url: string,
+                                     get_headers: (cookie: string) => HeadersInit,
+                                     check_response: (response: Response) => boolean
+): [
+  () => React.JSX.Element,
+  (redirect: Routes, callback: (headers: HeadersInit) => any) => void
+] {
+  async function checkAuth(cookies: Cookies): Promise<string | false> {
+    const cookie = stringifyCookies(cookies);
+    const response = await fetch(api_test_url, {
+      "method": "GET",
+      "headers": get_headers(cookie),
+    });
+    console.log(await response.text());
+    return check_response(response) && cookie;
+  }
+
+  function Auth() {
+    const {redirect}: { redirect: Routes } = useLocalSearchParams();
+    return (
+        <WebView
+            source={{uri: start_url}}
+            onNavigationStateChange={async (navState) => {
+              if (navState.url === start_url) {
+                const cookies = await CookieHandler.get(cookie_url, true);
+                if (await checkAuth(cookies)) {
+                  router.navigate({
+                    pathname: redirect,
+                    params: {[param_key]: encodeURIComponent(JSON.stringify(cookies))}
+                  });
+                }
+              }
+            }}
+            javaScriptEnabled={true}
+            domStorageEnabled={true}
+            startInLoadingState={false}
+            sharedCookiesEnabled={true}
+        />
+    );
+  }
+
+  async function handleCookies(cookies: Cookies): Promise<HeadersInit> {
+    const cookie = await checkAuth(cookies);
+    if (cookie) {
+      await AsyncStorage.setItem(cookie_key, JSON.stringify(cookies));
+      return get_headers(cookie);
+    } else {
+      throw "Authentication error";
+    }
+  }
+
+  function navigate(redirect: Routes) {
+    router.navigate({pathname, params: {redirect}});
+  }
+
+  function useAuth(redirect: Routes, callback: (headers: HeadersInit) => any): void {
+    const param = useLocalSearchParams()[param_key];
+    if (param) {
+      const cookieJSON = typeof param === "string" ? param : param[0];
+      const cookies: Cookies = JSON.parse(cookieJSON);
+      handleCookies(cookies).then(callback, () => navigate(redirect));
+    } else {
+      (async () => {
+        const cookieJSON = await AsyncStorage.getItem(cookie_key);
+        const cookies: Cookies = cookieJSON
+            ? JSON.parse(cookieJSON)
+            : await CookieHandler.get(cookie_url, true);
+        handleCookies(cookies).then(callback, () => navigate(redirect));
+      })();
+    }
+  }
+
+  return [Auth, useAuth];
+}
+


### PR DESCRIPTION
## Fix:

1. Create an [api transformer](https://github.com/tigeryu8900/api-transformer) server for transforming API calls
2. Use the new server in the code

## Why this works

The cookie manager for iOS is broken, and extra cookies are injected into the header. To mitigate this effect, we can encode the cookies in a different header by using api transformer so that the cookies injected by the cookie manager has no effect.

## Extra changes

Moved duplicate code from `app/canvas-auth.tsx` and `app/ucsb-auth.tsx` to `helpers/auth.tsx`.

closes #2